### PR TITLE
Cni integration

### DIFF
--- a/pkg/common/openstack.go
+++ b/pkg/common/openstack.go
@@ -1399,7 +1399,7 @@ func (os *OpenStack) SetupPod(podName, namespace, podInfraContainerID string, ne
 	// setup interface for pod
 	_, cidr, _ := net.ParseCIDR(subnet.Cidr)
 	prefixSize, _ := cidr.Mask.Size()
-	err = os.Plugin.SetupInterface(podName+"_"+namespace, podInfraContainerID, port,
+	err = os.Plugin.SetupInterface(podName+"_"+namespace, podInfraContainerID, namespace, port,
 		fmt.Sprintf("%s/%d", port.FixedIPs[0].IPAddress, prefixSize),
 		subnet.Gateway, dnsServers, containerRuntime)
 	if err != nil {

--- a/pkg/common/openstack.go
+++ b/pkg/common/openstack.go
@@ -330,6 +330,56 @@ func (os *OpenStack) ToProviderStatus(status string) string {
 	return "Failed"
 }
 
+func (os *OpenStack) CreateNetworkCNI(network *provider.NetConf) error {
+	opts := networks.CreateOpts{
+		Name:     network.Name,
+		TenantID: network.TenantID,
+	}
+	osNet, err := networks.Create(os.network, opts).Extract()
+	if err != nil {
+		return fmt.Errorf("Create openstack network %s failed: %v", network.Name, err)
+	}
+
+	// create router
+	routerOpts := routers.CreateOpts{
+		Name:        network.Name,
+		TenantID:    network.TenantID,
+		GatewayInfo: &routers.GatewayInfo{NetworkID: os.ExtNetID},
+	}
+	osRouter, err := routers.Create(os.network, routerOpts).Extract()
+	if err != nil {
+		//os.DeleteNetwork(network.Name)
+		return fmt.Errorf("Create openstack router %s failed: %v", network.Name, err)
+	}
+
+	// create subnet and connect them to router
+	network.NetworkID = osNet.ID
+	subnetOpts := subnets.CreateOpts{
+		NetworkID: network.NetworkID,
+		CIDR:      network.SubnetCidr,
+		Name:      network.SubnetName,
+		IPVersion: gophercloud.IPv4,
+		TenantID:  network.TenantID,
+		GatewayIP: &network.SubnetGateway,
+	}
+	s, err := subnets.Create(os.network, subnetOpts).Extract()
+	if err != nil {
+		// os.DeleteNetwork(network.Name)
+		return fmt.Errorf("Create openstack subnet %s failed: %v", network.SubnetName, err)
+	}
+
+	// add subnet to router
+	addOpts := routers.AddInterfaceOpts{
+		SubnetID: s.ID,
+	}
+	_, err = routers.AddInterface(os.network, osRouter.ID, addOpts).Extract()
+	if err != nil {
+		return fmt.Errorf("Add openstack subnet %s to router %s failed: %v", network.SubnetName, err)
+	}
+
+	return nil
+}
+
 // Create network
 func (os *OpenStack) CreateNetwork(network *provider.Network) error {
 	if len(network.Subnets) == 0 {
@@ -637,8 +687,8 @@ func (os *OpenStack) CreatePort(networkID, tenantID, portName, podHostname strin
 	}
 
 	opts := portsbinding.CreateOpts{
-		HostID:  getHostName(),
-		DNSName: podHostname,
+		HostID: getHostName(),
+		//DNSName: podHostname,
 		CreateOptsBuilder: ports.CreateOpts{
 			NetworkID:      networkID,
 			Name:           portName,
@@ -657,15 +707,15 @@ func (os *OpenStack) CreatePort(networkID, tenantID, portName, podHostname strin
 	}
 
 	// Update dns_name in order to make sure it is correct
-	updateOpts := portsbinding.UpdateOpts{
-		DNSName: podHostname,
-	}
-	_, err = portsbinding.Update(os.network, port.ID, updateOpts).Extract()
-	if err != nil {
-		ports.Delete(os.network, port.ID)
-		glog.Errorf("Update port %s failed: %v", portName, err)
-		return nil, err
-	}
+	/*	updateOpts := portsbinding.UpdateOpts{
+			DNSName: podHostname,
+		}
+		_, err = portsbinding.Update(os.network, port.ID, updateOpts).Extract()
+		if err != nil {
+			ports.Delete(os.network, port.ID)
+			glog.Errorf("Update port %s failed: %v", portName, err)
+			return nil, err
+		}*/
 
 	return port, nil
 }
@@ -1331,6 +1381,58 @@ func (os *OpenStack) CheckTenantID(tenantID string) (bool, error) {
 
 func (os *OpenStack) BuildPortName(podName, namespace, networkID string) string {
 	return podNamePrefix + "_" + podName + "_" + namespace + "_" + networkID
+}
+
+func (os *OpenStack) SetupPodCNI(podName, namespace, podInfraContainerID string, network *provider.NetConf) (*current.Result, error) {
+	portName := os.BuildPortName(podName, namespace, network.NetworkID)
+
+	// get dns server ips
+	dnsServers := make([]string, 0, 1)
+	networkPorts, err := os.ListPorts(network.NetworkID, "network:dhcp")
+	if err != nil {
+		return nil, fmt.Errorf("Query dhcp ports failed: %v", err)
+	}
+	for _, p := range networkPorts {
+		dnsServers = append(dnsServers, p.FixedIPs[0].IPAddress)
+	}
+
+	// get port from openstack; if port doesn't exist, create a new one
+	port, err := os.GetPort(portName)
+	if err == ErrNotFound || port == nil {
+		/*		podHostname := strings.Split(podName, "_")[0]
+				if len(podHostname) > hostnameMaxLen {
+					podHostname = podHostname[:hostnameMaxLen]
+				}*/
+
+		// Port not found, create one
+		portWithBinding, err := os.CreatePort(network.NetworkID, network.TenantID, portName, "")
+		if err != nil {
+			return nil, fmt.Errorf("CreatePort failed: %v", err)
+		}
+		port = &portWithBinding.Port
+	} else if err != nil {
+		return nil, fmt.Errorf("GetPort failed: %v", err)
+	}
+
+	// get subnet and gateway
+	subnet, err := os.getProviderSubnet(port.FixedIPs[0].SubnetID)
+	if err != nil {
+		//ports.Delete(os.network, port.ID).ExtractErr()
+		return nil, fmt.Errorf("Get info os subnet %s failed: %v", port.FixedIPs[0].SubnetID, err)
+	}
+
+	// setup interface for pod
+	_, cidr, _ := net.ParseCIDR(subnet.Cidr)
+	prefixSize, _ := cidr.Mask.Size()
+	result, err := os.Plugin.SetupInterface(podName+"_"+namespace, podInfraContainerID, namespace, port,
+		fmt.Sprintf("%s/%d", port.FixedIPs[0].IPAddress, prefixSize),
+		subnet.Gateway, dnsServers, "")
+	if err != nil {
+		//ports.Delete(os.network, port.ID).ExtractErr()
+		return nil, fmt.Errorf("SetupInterface failed: %v", err)
+	}
+
+	return result, nil
 }
 
 // Setup pod

--- a/pkg/kubestack/kubestack.go
+++ b/pkg/kubestack/kubestack.go
@@ -208,7 +208,7 @@ func (h *KubeHandler) SetupPod(c context.Context, req *provider.SetupPodRequest)
 
 	resp := provider.CommonResponse{}
 	// TODO: Add hostname in SetupPod Interface
-	err := h.driver.SetupPod(req.PodName, req.Namespace, req.PodInfraContainerID, req.Network, req.ContainerRuntime)
+	_, err := h.driver.SetupPod(req.PodName, req.Namespace, req.PodInfraContainerID, req.Network, req.ContainerRuntime)
 	if err != nil {
 		glog.Errorf("SetupPod failed: %v", err)
 		resp.Error = err.Error()

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -25,7 +25,7 @@ import (
 )
 
 type PluginInterface interface {
-	SetupInterface(podName, podInfraContainerID string, port *ports.Port, ipcidr, gateway string, dnsServers []string, containerRuntime string) error
+	SetupInterface(podName, podInfraContainerID, namespace string, port *ports.Port, ipcidr, gateway string, dnsServers []string, containerRuntime string) error
 	DestroyInterface(podName, podInfraContainerID string, port *ports.Port, containerRuntime string) error
 	Init(integrationBridge string) error
 }

--- a/pkg/plugins/plugins.go
+++ b/pkg/plugins/plugins.go
@@ -20,12 +20,13 @@ import (
 	"fmt"
 	"sync"
 
+	"github.com/containernetworking/cni/pkg/types/current"
 	"github.com/golang/glog"
 	"github.com/gophercloud/gophercloud/openstack/networking/v2/ports"
 )
 
 type PluginInterface interface {
-	SetupInterface(podName, podInfraContainerID, namespace string, port *ports.Port, ipcidr, gateway string, dnsServers []string, containerRuntime string) error
+	SetupInterface(podName, podInfraContainerID, namespace string, port *ports.Port, ipcidr, gateway string, dnsServers []string, containerRuntime string) (*current.Result, error)
 	DestroyInterface(podName, podInfraContainerID string, port *ports.Port, containerRuntime string) error
 	Init(integrationBridge string) error
 }

--- a/pkg/types/types.go
+++ b/pkg/types/types.go
@@ -1,0 +1,31 @@
+/*
+Copyright 2015 The Kubernetes Authors All rights reserved.
+
+Licensed under the Apache License, Version 2.0 (the "License");
+you may not use this file except in compliance with the License.
+You may obtain a copy of the License at
+
+    http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing, software
+distributed under the License is distributed on an "AS IS" BASIS,
+WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+See the License for the specific language governing permissions and
+limitations under the License.
+*/
+
+package types
+
+import (
+	cnitypes "github.com/containernetworking/cni/pkg/types"
+)
+
+type NetConf struct {
+	cnitypes.NetConf
+	NetworkID     string `json:"networkId"`
+	TenantID      string `json:"tenantId"`
+	TenantName    string `json:"tenanName"`
+	SubnetName    string `json:"subnetName"`
+	SubnetCidr    string `json:"subnetCidr"`
+	SubnetGateway string `json:"subnetGateway"`
+}


### PR DESCRIPTION
Basic Network adding function enabled.
Notes: The OpenStack and kubestack should be configured same as in Hypernetes.
The cni configuration file should look like this:
{
    "cniVersion": "0.3.0",
    "name": "abc",
    "type": "kubestack",
    "tenanName": "admin",
    "subnetName": "abcsub",
    "subnetCidr": "192.168.1.0/24",
    "subnetGateway": "192.168.1.1"
}
Put the `kubestack` binary into $GOPATH/src/github.com/containernetworking/cni/bin and go to $GOPATH/src/github.com/containernetworking/cni/.
Execute the following instruction:
$ CNI_PATH=`pwd`/bin
$ cd scripts
$ sudo CNI_PATH=$CNI_PATH ./priv-net-run.sh ifconfig

We should be able to see the following output:
[root@VM_113_1_centos scripts(keystone_admin)]# sudo CNI_PATH=$CNI_PATH ./priv-net-run.sh ifconfig
eth0: flags=4163<UP,BROADCAST,RUNNING,MULTICAST>  mtu 1500
        inet 192.168.1.3  netmask 255.255.255.0  broadcast 0.0.0.0
        inet6 fe80::f816:3eff:febc:5cd2  prefixlen 64  scopeid 0x20<link>
        ether fa:16:3e:bc:5c:d2  txqueuelen 1000  (Ethernet)
        RX packets 0  bytes 0 (0.0 B)
        RX errors 0  dropped 0  overruns 0  frame 0
        TX packets 1  bytes 90 (90.0 B)
        TX errors 0  dropped 0 overruns 0  carrier 0  collisions 0
Now the work is still very preliminary，but also continue to improve.