### PR TITLE
Check portID of fip

### DIFF
--- a/pkg/common/openstack.go
+++ b/pkg/common/openstack.go
@@ -694,8 +694,12 @@ func (os *OpenStack) BindPortToFloatingip(portID, floatingIPAddress, tenantID st
 	}
 
 	if fip != nil {
-		// fip has already been used
 		if fip.PortID != "" {
+			if fip.PortID == portID {
+				glog.V(3).Infof("FIP %q has already been associated with port %q", floatingIPAddress, portID)
+				return nil
+			}
+			// fip has already been used
 			return fmt.Errorf("FloatingIP %v is already been binded to %v", floatingIPAddress, fip.PortID)
 		}
 


### PR DESCRIPTION
Do not fail if the fip has already been associated with correct port.